### PR TITLE
fix: Remove unused import in VeggieCard (PR #20 nit)

### DIFF
--- a/apps/web/src/components/VeggieCard/VeggieCard.tsx
+++ b/apps/web/src/components/VeggieCard/VeggieCard.tsx
@@ -1,4 +1,3 @@
-import { useTableData } from '@/context';
 import styles from './VeggieCard.module.scss';
 
 interface VeggieCardProps {


### PR DESCRIPTION
## Summary
- Remove unused `useTableData` import from `VeggieCard.tsx` that would fail linting

## Context
Addresses review feedback from PR #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)