### PR TITLE
fix: Address PR #18 auth middleware review nits

### DIFF
--- a/apps/server/src/middleware/auth.ts
+++ b/apps/server/src/middleware/auth.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import type { Request, Response, NextFunction } from 'express';
 import { UnauthorizedError } from '../types/errors';
 
@@ -22,7 +23,11 @@ export const authentication = (
 
     // Extract request token and compare it with the access code
     const token = authHeader.split(' ')[1];
-    if (token !== process.env.ACCESS_CODE) {
+    const accessCode = process.env.ACCESS_CODE ?? '';
+    if (
+        token.length !== accessCode.length ||
+        !crypto.timingSafeEqual(Buffer.from(token), Buffer.from(accessCode))
+    ) {
         next(new UnauthorizedError("Invalid access token."));
         return;
     }

--- a/apps/server/src/types/errors.ts
+++ b/apps/server/src/types/errors.ts
@@ -30,6 +30,6 @@ export class UnauthorizedError extends AppError {
     message: string
   ) {
     super(401, `User unauthorized. ${message}`);
-    this.name = 'AuthorizationError';
+    this.name = 'UnauthorizedError';
   }
 }


### PR DESCRIPTION
## Summary
- Use `crypto.timingSafeEqual` for timing-safe token comparison in auth middleware
- Fix mismatched error class name (`UnauthorizedError` now correctly sets `this.name = 'UnauthorizedError'`)

## Context
Addresses review feedback from PR #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)