### PR TITLE
feat: add days since last delivery column

### DIFF
--- a/apps/server/src/services/googleSheetsService.ts
+++ b/apps/server/src/services/googleSheetsService.ts
@@ -30,6 +30,16 @@ const rowsToObjects = (values: string[][]): Record<string, string>[] => {
   });
 };
 
+// Full-day calendar difference using each date's local Y/M/D. Anchoring at
+// UTC midnight sidesteps DST transitions (where wall-clock ms subtraction
+// would be off by an hour) and the UTC-vs-local parsing discrepancy for
+// "YYYY-MM-DD" strings.
+const daysBetween = (from: Date, to: Date): number => {
+  const fromUtc = Date.UTC(from.getFullYear(), from.getMonth(), from.getDate());
+  const toUtc = Date.UTC(to.getFullYear(), to.getMonth(), to.getDate());
+  return Math.max(0, Math.floor((toUtc - fromUtc) / (1000 * 60 * 60 * 24)));
+};
+
 const isSameMonth = (date: string, present = new Date(2025, 10)) => {
   const d = new Date(date);
   return (
@@ -162,9 +172,7 @@ export const getParsedNonprofitData = async () => {
         ? totals.lastDelivery.toISOString().split('T')[0]
         : null,
       daysSinceLastDelivery: totals.lastDelivery
-        ? Math.floor(
-            (Date.now() - totals.lastDelivery.getTime()) / (1000 * 60 * 60 * 24),
-          )
+        ? daysBetween(totals.lastDelivery, new Date())
         : null,
       totalDeliveriesThisMonth: totals.totalDeliveriesThisMonth,
       totalPoundsThisMonth: totals.totalPoundsThisMonth,

--- a/apps/server/src/services/googleSheetsService.ts
+++ b/apps/server/src/services/googleSheetsService.ts
@@ -30,13 +30,21 @@ const rowsToObjects = (values: string[][]): Record<string, string>[] => {
   });
 };
 
-// Full-day calendar difference using each date's local Y/M/D. Anchoring at
-// UTC midnight sidesteps DST transitions (where wall-clock ms subtraction
-// would be off by an hour) and the UTC-vs-local parsing discrepancy for
-// "YYYY-MM-DD" strings.
+// Full-day calendar difference in UTC. `new Date("YYYY-MM-DD")` parses as
+// UTC midnight, so using UTC getters on both sides keeps the comparison in
+// the same reference frame regardless of the server's local timezone. This
+// also avoids DST boundary errors that raw ms subtraction would introduce.
 const daysBetween = (from: Date, to: Date): number => {
-  const fromUtc = Date.UTC(from.getFullYear(), from.getMonth(), from.getDate());
-  const toUtc = Date.UTC(to.getFullYear(), to.getMonth(), to.getDate());
+  const fromUtc = Date.UTC(
+    from.getUTCFullYear(),
+    from.getUTCMonth(),
+    from.getUTCDate(),
+  );
+  const toUtc = Date.UTC(
+    to.getUTCFullYear(),
+    to.getUTCMonth(),
+    to.getUTCDate(),
+  );
   return Math.max(0, Math.floor((toUtc - fromUtc) / (1000 * 60 * 60 * 24)));
 };
 

--- a/apps/server/src/services/googleSheetsService.ts
+++ b/apps/server/src/services/googleSheetsService.ts
@@ -161,6 +161,11 @@ export const getParsedNonprofitData = async () => {
       lastDelivery: totals.lastDelivery
         ? totals.lastDelivery.toISOString().split('T')[0]
         : null,
+      daysSinceLastDelivery: totals.lastDelivery
+        ? Math.floor(
+            (Date.now() - totals.lastDelivery.getTime()) / (1000 * 60 * 60 * 24),
+          )
+        : null,
       totalDeliveriesThisMonth: totals.totalDeliveriesThisMonth,
       totalPoundsThisMonth: totals.totalPoundsThisMonth,
       totalDeliveriesThisYear: totals.totalDeliveriesThisYear,


### PR DESCRIPTION
## Summary
- Adds a `daysSinceLastDelivery` computed column to the dashboard data
- Derived from the existing `lastDelivery` date using `Math.floor((now - lastDelivery) / msPerDay)`
- Flows through automatically as a new column in the dashboard table

## Test plan
- [ ] Verify the new column appears in the dashboard table
- [ ] Confirm values are correct relative to each recipient's last delivery date
- [ ] Confirm recipients with no deliveries show null

🤖 Generated with [Claude Code](https://claude.com/claude-code)