### PR TITLE
feat: recipients table with full sheet data

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -7,6 +7,7 @@ import { corsOptions } from './middleware/cors';
 import { errorHandler } from './middleware/errorHandler';
 import { rateLimit } from './middleware/rateLimit';
 import donationRoutes from './routes/donations';
+import recipientRoutes from './routes/recipients';
 import sheetsRoutes from './routes/sheets';
 
 const app = express();
@@ -27,6 +28,7 @@ app.get('/health', (req: Request, res: Response) => {
 
 app.use('/donations', authentication, donationRoutes);
 app.use('/sheets', authentication, sheetsRoutes);
+app.use('/recipients', recipientRoutes);
 app.use('/testing', testing);
 
 app.use(errorHandler);

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -28,7 +28,7 @@ app.get('/health', (req: Request, res: Response) => {
 
 app.use('/donations', authentication, donationRoutes);
 app.use('/sheets', authentication, sheetsRoutes);
-app.use('/recipients', recipientRoutes);
+app.use('/recipients', authentication, recipientRoutes);
 app.use('/testing', testing);
 
 app.use(errorHandler);

--- a/apps/server/src/routes/recipients.ts
+++ b/apps/server/src/routes/recipients.ts
@@ -4,17 +4,12 @@ import { getParsedRecipientData } from '../services/googleSheetsService';
 
 const router = Router();
 
-router.get('/', async (req, res) => {
+router.get('/', async (req, res, next) => {
   try {
     const data = await getParsedRecipientData();
-    const stringified = data.map((row) =>
-      Object.fromEntries(
-        Object.entries(row).map(([k, v]) => [k, String(v ?? '')])
-      )
-    );
-    res.json(stringified);
+    res.json(data);
   } catch (error) {
-    res.status(500).json({ error: 'Failed to fetch recipient data' });
+    next(error);
   }
 });
 

--- a/apps/server/src/routes/recipients.ts
+++ b/apps/server/src/routes/recipients.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+
+import { getParsedRecipientData } from '../services/googleSheetsService';
+
+const router = Router();
+
+router.get('/', async (req, res) => {
+  try {
+    const data = await getParsedRecipientData();
+    res.json(data);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch recipient data' });
+  }
+});
+
+export default router;

--- a/apps/server/src/routes/recipients.ts
+++ b/apps/server/src/routes/recipients.ts
@@ -7,7 +7,12 @@ const router = Router();
 router.get('/', async (req, res) => {
   try {
     const data = await getParsedRecipientData();
-    res.json(data);
+    const stringified = data.map((row) =>
+      Object.fromEntries(
+        Object.entries(row).map(([k, v]) => [k, String(v ?? '')])
+      )
+    );
+    res.json(stringified);
   } catch (error) {
     res.status(500).json({ error: 'Failed to fetch recipient data' });
   }

--- a/apps/server/src/services/googleSheetsService.ts
+++ b/apps/server/src/services/googleSheetsService.ts
@@ -48,6 +48,23 @@ type RecipientInfo = {
   location: string | null;
 };
 
+type RecipientRow = {
+  name: string;
+  accepts: string;
+  orgType: string;
+  demographicServed: string;
+  location: string;
+  priority: number | null;
+  address: string;
+  availableDeliveryDays: string;
+  contact: string;
+  contactPhone: string;
+  officeContact: string;
+  officePhone: string;
+  officeEmail: string;
+  notes: string;
+};
+
 type Totals = {
   lastDelivery: Date | null;
   totalDeliveriesThisMonth: number | 0;
@@ -176,4 +193,32 @@ export const getParsedNonprofitData = async () => {
   });
 
   return result;
+};
+
+export const getParsedRecipientData = async (): Promise<RecipientRow[]> => {
+  const recipientData = await fetchSheetValues(
+    '13tTXxSsk59AuCTKTW_6u2wNCcuenXBATYdB10AKgN88',
+    'Food_Recipients!A:O',
+  );
+
+  const recipientObjects = rowsToObjects(recipientData);
+
+  return recipientObjects
+    .filter((r) => r['Name'])
+    .map((r) => ({
+      name: r['Name'],
+      accepts: r['Accepts'] ?? '',
+      orgType: r['Org Type'] ?? '',
+      demographicServed: r['Demographic Served'] ?? '',
+      location: r['location'] ?? '',
+      priority: r['priority'] ? Number(r['priority']) : null,
+      address: r['Address'] ?? '',
+      availableDeliveryDays: r['available delivery days'] ?? '',
+      contact: r['Contact'] ?? '',
+      contactPhone: r['Contact Phone'] ?? '',
+      officeContact: r['Office Contact'] ?? '',
+      officePhone: r['Office Phone'] ?? '',
+      officeEmail: r['Office Email'] ?? '',
+      notes: r['Notes'] ?? '',
+    }));
 };

--- a/apps/server/src/services/googleSheetsService.ts
+++ b/apps/server/src/services/googleSheetsService.ts
@@ -48,13 +48,13 @@ type RecipientInfo = {
   location: string | null;
 };
 
-type RecipientRow = {
+export type RecipientRow = {
   name: string;
   accepts: string;
   orgType: string;
   demographicServed: string;
   location: string;
-  priority: number | null;
+  priority: string;
   address: string;
   availableDeliveryDays: string;
   contact: string;
@@ -195,6 +195,26 @@ export const getParsedNonprofitData = async () => {
   return result;
 };
 
+// Header keys here must match the exact casing/spacing used in the
+// Food_Recipients sheet (note: some are lowercase, e.g. "location",
+// "priority", "available delivery days").
+const RECIPIENT_HEADERS = {
+  name: 'Name',
+  accepts: 'Accepts',
+  orgType: 'Org Type',
+  demographicServed: 'Demographic Served',
+  location: 'location',
+  priority: 'priority',
+  address: 'Address',
+  availableDeliveryDays: 'available delivery days',
+  contact: 'Contact',
+  contactPhone: 'Contact Phone',
+  officeContact: 'Office Contact',
+  officePhone: 'Office Phone',
+  officeEmail: 'Office Email',
+  notes: 'Notes',
+} as const satisfies Record<keyof RecipientRow, string>;
+
 export const getParsedRecipientData = async (): Promise<RecipientRow[]> => {
   const recipientData = await fetchSheetValues(
     '13tTXxSsk59AuCTKTW_6u2wNCcuenXBATYdB10AKgN88',
@@ -204,21 +224,15 @@ export const getParsedRecipientData = async (): Promise<RecipientRow[]> => {
   const recipientObjects = rowsToObjects(recipientData);
 
   return recipientObjects
-    .filter((r) => r['Name'])
-    .map((r) => ({
-      name: r['Name'],
-      accepts: r['Accepts'] ?? '',
-      orgType: r['Org Type'] ?? '',
-      demographicServed: r['Demographic Served'] ?? '',
-      location: r['location'] ?? '',
-      priority: r['priority'] ? Number(r['priority']) : null,
-      address: r['Address'] ?? '',
-      availableDeliveryDays: r['available delivery days'] ?? '',
-      contact: r['Contact'] ?? '',
-      contactPhone: r['Contact Phone'] ?? '',
-      officeContact: r['Office Contact'] ?? '',
-      officePhone: r['Office Phone'] ?? '',
-      officeEmail: r['Office Email'] ?? '',
-      notes: r['Notes'] ?? '',
-    }));
+    .filter((r) => r[RECIPIENT_HEADERS.name])
+    .map((r) => {
+      const row = {} as RecipientRow;
+      for (const [field, header] of Object.entries(RECIPIENT_HEADERS) as [
+        keyof RecipientRow,
+        string,
+      ][]) {
+        row[field] = r[header] ?? '';
+      }
+      return row;
+    });
 };

--- a/apps/web/src/app/recipients/page.tsx
+++ b/apps/web/src/app/recipients/page.tsx
@@ -14,7 +14,7 @@ export default function Recipients() {
     // TODO: adjust fetch route when the backend route changes
     async function fetchData() {
       try {
-        const res = await fetch('http://localhost:3000/testing');
+        const res = await fetch('http://localhost:3000/recipients');
 
         if (!res.ok) {
           throw new Error('HTTP error. Could not fetch data.');


### PR DESCRIPTION
## Summary
- Adds `getParsedRecipientData()` to pull all columns (A:O) from the Food_Recipients sheet — Accepts, Org Type, Demographic Served, available delivery days, Contact, Contact Phone, Office Contact, Office Phone, Office Email, Notes, location, priority, and address
- Adds `/recipients` API route to serve this data
- Updates the recipients page to fetch from `/recipients` instead of `/testing`

Closes #29

## Test plan
- [ ] Hit `GET /recipients` and verify all 14 fields are returned per recipient
- [ ] Verify the recipients page renders the full table with all columns
- [ ] Confirm rows with no `Name` are filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)