### PR TITLE
top5recommendation

### DIFF
--- a/apps/server/src/__tests__/deliveries.test.ts
+++ b/apps/server/src/__tests__/deliveries.test.ts
@@ -1,0 +1,129 @@
+import type { Response } from 'supertest';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/googleSheetsService', () => ({
+  getParsedNonprofitData: vi.fn(),
+}));
+
+import app from '../app';
+import { getParsedNonprofitData } from '../services/googleSheetsService';
+
+const getBody = <T>(res: Response): T => res.body as T;
+
+describe('Deliveries API', () => {
+  beforeEach(() => {
+    process.env.ACCESS_CODE = 'test-access-code';
+    vi.clearAllMocks();
+  });
+
+  it('returns a ranked delivery queue of exactly five recipients', async () => {
+    vi.mocked(getParsedNonprofitData).mockResolvedValue([
+      {
+        recipient: 'North Pantry',
+        lastDelivery: '2026-04-01',
+        daysSinceLastDelivery: 20,
+        totalDeliveriesThisMonth: 1,
+        totalPoundsThisMonth: 50,
+        totalDeliveriesThisYear: 5,
+        totalPoundsThisYear: 300,
+        avgPoundsPerDelivery: 50,
+        priorityLevel: 1,
+        deliveryFrequency: 'None',
+        location: 'North, CA',
+      },
+      {
+        recipient: 'South Kitchen',
+        lastDelivery: '2026-04-10',
+        daysSinceLastDelivery: 11,
+        totalDeliveriesThisMonth: 2,
+        totalPoundsThisMonth: 90,
+        totalDeliveriesThisYear: 10,
+        totalPoundsThisYear: 700,
+        avgPoundsPerDelivery: 45,
+        priorityLevel: 2,
+        deliveryFrequency: 'Low',
+        location: 'South, CA',
+      },
+      {
+        recipient: 'East Mission',
+        lastDelivery: '2026-04-15',
+        daysSinceLastDelivery: 6,
+        totalDeliveriesThisMonth: 6,
+        totalPoundsThisMonth: 220,
+        totalDeliveriesThisYear: 15,
+        totalPoundsThisYear: 1200,
+        avgPoundsPerDelivery: 36.7,
+        priorityLevel: 4,
+        deliveryFrequency: 'High',
+        location: 'East, CA',
+      },
+      {
+        recipient: 'West Support',
+        lastDelivery: '2026-04-08',
+        daysSinceLastDelivery: 13,
+        totalDeliveriesThisMonth: 2,
+        totalPoundsThisMonth: 80,
+        totalDeliveriesThisYear: 9,
+        totalPoundsThisYear: 640,
+        avgPoundsPerDelivery: 40,
+        priorityLevel: 2,
+        deliveryFrequency: 'Low',
+        location: 'West, CA',
+      },
+      {
+        recipient: 'Central Aid',
+        lastDelivery: '2026-04-05',
+        daysSinceLastDelivery: 16,
+        totalDeliveriesThisMonth: 1,
+        totalPoundsThisMonth: 60,
+        totalDeliveriesThisYear: 7,
+        totalPoundsThisYear: 390,
+        avgPoundsPerDelivery: 60,
+        priorityLevel: 1,
+        deliveryFrequency: 'None',
+        location: 'Central, CA',
+      },
+      {
+        recipient: 'Harbor Help',
+        lastDelivery: '2026-04-18',
+        daysSinceLastDelivery: 3,
+        totalDeliveriesThisMonth: 7,
+        totalPoundsThisMonth: 300,
+        totalDeliveriesThisYear: 20,
+        totalPoundsThisYear: 1800,
+        avgPoundsPerDelivery: 42.8,
+        priorityLevel: 5,
+        deliveryFrequency: 'High',
+        location: 'Harbor, CA',
+      },
+    ]);
+
+    const response = await request(app)
+      .get('/deliveries/queue')
+      .set('Authorization', 'Bearer test-access-code');
+
+    expect(response.status).toBe(200);
+
+    const body = getBody<
+      Array<{
+        foodRecipient: string;
+        needScore: number;
+        location: string | null;
+        daysSinceLastDelivery: number | null;
+      }>
+    >(response);
+
+    expect(body).toHaveLength(5);
+    expect(body[0]?.needScore).toBeGreaterThanOrEqual(body[1]?.needScore ?? 0);
+    expect(body[4]?.needScore).toBeGreaterThanOrEqual(0);
+    expect(body[0]).toEqual(
+      expect.objectContaining({
+        foodRecipient: expect.any(String),
+        needScore: expect.any(Number),
+        location: expect.any(String),
+        daysSinceLastDelivery: expect.any(Number),
+      }),
+    );
+  });
+});

--- a/apps/server/src/__tests__/deliveryQueueService.test.ts
+++ b/apps/server/src/__tests__/deliveryQueueService.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  generateDeliveryQueue,
+  type NonprofitDeliveryData,
+} from '../services/deliveryQueueService';
+
+describe('generateDeliveryQueue', () => {
+  it('computes need score from weighted one-sided z-scores using median/std', () => {
+    const recipients: NonprofitDeliveryData[] = [
+      {
+        recipient: 'Neediest Org',
+        daysSinceLastDelivery: 2,
+        priorityLevel: 0,
+        totalPoundsThisMonth: 0,
+        totalDeliveriesThisMonth: 0,
+        deliveryFrequency: 'None',
+        location: 'North, CA',
+      },
+      {
+        recipient: 'Recently Served Org',
+        daysSinceLastDelivery: 0,
+        priorityLevel: 2,
+        totalPoundsThisMonth: 2,
+        totalDeliveriesThisMonth: 2,
+        deliveryFrequency: 'High',
+        location: 'South, CA',
+      },
+    ];
+
+    const queue = generateDeliveryQueue(recipients);
+    const neediest = queue.find((r) => r.foodRecipient === 'Neediest Org');
+    const recentlyServed = queue.find(
+      (r) => r.foodRecipient === 'Recently Served Org',
+    );
+
+    // All five weighted components contribute exactly 1 std-dev in the
+    // intended direction for "Neediest Org", so weighted sum is 1.00.
+    expect(neediest?.needScore).toBe(100);
+    expect(recentlyServed?.needScore).toBe(0);
+  });
+
+  it('rounds need scores to one decimal place', () => {
+    const recipients: NonprofitDeliveryData[] = [
+      {
+        recipient: 'High Days',
+        daysSinceLastDelivery: 2,
+        priorityLevel: 2,
+        totalPoundsThisMonth: 100,
+        totalDeliveriesThisMonth: 3,
+        deliveryFrequency: 'Low',
+        location: 'A',
+      },
+      {
+        recipient: 'Median Days',
+        daysSinceLastDelivery: 1,
+        priorityLevel: 2,
+        totalPoundsThisMonth: 100,
+        totalDeliveriesThisMonth: 3,
+        deliveryFrequency: 'Low',
+        location: 'B',
+      },
+      {
+        recipient: 'Low Days',
+        daysSinceLastDelivery: 0,
+        priorityLevel: 2,
+        totalPoundsThisMonth: 100,
+        totalDeliveriesThisMonth: 3,
+        deliveryFrequency: 'Low',
+        location: 'C',
+      },
+    ];
+
+    const queue = generateDeliveryQueue(recipients);
+    const highDays = queue.find((r) => r.foodRecipient === 'High Days');
+
+    expect(highDays?.needScore).toBe(42.9);
+  });
+
+  it('returns top 5 recipients sorted by need score descending', () => {
+    const recipients: NonprofitDeliveryData[] = [
+      {
+        recipient: 'Alpha Pantry',
+        daysSinceLastDelivery: 30,
+        priorityLevel: 1,
+        totalPoundsThisMonth: 50,
+        totalDeliveriesThisMonth: 1,
+        deliveryFrequency: 'None',
+        location: 'A',
+      },
+      {
+        recipient: 'Bravo Kitchen',
+        daysSinceLastDelivery: 20,
+        priorityLevel: 2,
+        totalPoundsThisMonth: 80,
+        totalDeliveriesThisMonth: 2,
+        deliveryFrequency: 'Low',
+        location: 'B',
+      },
+      {
+        recipient: 'Charlie Center',
+        daysSinceLastDelivery: 10,
+        priorityLevel: 3,
+        totalPoundsThisMonth: 120,
+        totalDeliveriesThisMonth: 4,
+        deliveryFrequency: 'Medium',
+        location: 'C',
+      },
+      {
+        recipient: 'Delta Mission',
+        daysSinceLastDelivery: 5,
+        priorityLevel: 4,
+        totalPoundsThisMonth: 200,
+        totalDeliveriesThisMonth: 8,
+        deliveryFrequency: 'High',
+        location: 'D',
+      },
+      {
+        recipient: 'Echo Support',
+        daysSinceLastDelivery: 15,
+        priorityLevel: 2,
+        totalPoundsThisMonth: 90,
+        totalDeliveriesThisMonth: 2,
+        deliveryFrequency: 'Low',
+        location: 'E',
+      },
+      {
+        recipient: 'Foxtrot Relief',
+        daysSinceLastDelivery: 40,
+        priorityLevel: 1,
+        totalPoundsThisMonth: 40,
+        totalDeliveriesThisMonth: 1,
+        deliveryFrequency: 'None',
+        location: 'F',
+      },
+    ];
+
+    const queue = generateDeliveryQueue(recipients);
+
+    expect(queue).toHaveLength(5);
+    expect(queue.map((r) => r.needScore)).toEqual(
+      [...queue.map((r) => r.needScore)].sort((a, b) => b - a),
+    );
+    expect(queue.some((r) => r.foodRecipient === 'Delta Mission')).toBe(false);
+  });
+
+  it('applies one-sided directional scoring and ignores opposite direction', () => {
+    const recipients: NonprofitDeliveryData[] = [
+      {
+        recipient: 'Needs Days',
+        daysSinceLastDelivery: 10,
+        priorityLevel: 5,
+        totalPoundsThisMonth: 500,
+        totalDeliveriesThisMonth: 10,
+        deliveryFrequency: 'High',
+        location: 'North',
+      },
+      {
+        recipient: 'Baseline A',
+        daysSinceLastDelivery: 1,
+        priorityLevel: 1,
+        totalPoundsThisMonth: 100,
+        totalDeliveriesThisMonth: 1,
+        deliveryFrequency: 'Low',
+        location: 'South',
+      },
+      {
+        recipient: 'Baseline B',
+        daysSinceLastDelivery: 1,
+        priorityLevel: 1,
+        totalPoundsThisMonth: 100,
+        totalDeliveriesThisMonth: 1,
+        deliveryFrequency: 'Low',
+        location: 'East',
+      },
+    ];
+
+    const queue = generateDeliveryQueue(recipients);
+    const needsDays = queue.find((r) => r.foodRecipient === 'Needs Days');
+    const baselineA = queue.find((r) => r.foodRecipient === 'Baseline A');
+
+    expect(needsDays?.needScore).toBeGreaterThan(0);
+    expect(baselineA?.needScore).toBe(0);
+  });
+
+  it('treats missing priority as neutral and still includes recipients', () => {
+    const recipients: NonprofitDeliveryData[] = [
+      {
+        recipient: 'Org 1',
+        daysSinceLastDelivery: 7,
+        priorityLevel: null,
+        totalPoundsThisMonth: 100,
+        totalDeliveriesThisMonth: 3,
+        deliveryFrequency: 'Low',
+        location: undefined,
+      },
+      {
+        recipient: 'Org 2',
+        daysSinceLastDelivery: 7,
+        priorityLevel: null,
+        totalPoundsThisMonth: 100,
+        totalDeliveriesThisMonth: 3,
+        deliveryFrequency: 'Low',
+        location: undefined,
+      },
+    ];
+
+    const queue = generateDeliveryQueue(recipients);
+
+    expect(queue).toHaveLength(2);
+    expect(queue[0]?.needScore).toBe(0);
+    expect(queue[1]?.needScore).toBe(0);
+  });
+
+  it('excludes recipients with missing non-priority required scoring inputs', () => {
+    const recipients: NonprofitDeliveryData[] = [
+      {
+        recipient: 'Missing Days',
+        daysSinceLastDelivery: null,
+        priorityLevel: 2,
+        totalPoundsThisMonth: 100,
+        totalDeliveriesThisMonth: 3,
+        deliveryFrequency: 'Low',
+        location: 'A',
+      },
+      {
+        recipient: 'Valid Org',
+        daysSinceLastDelivery: 7,
+        priorityLevel: 2,
+        totalPoundsThisMonth: 100,
+        totalDeliveriesThisMonth: 3,
+        deliveryFrequency: 'Low',
+        location: 'B',
+      },
+    ];
+
+    const queue = generateDeliveryQueue(recipients);
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0]?.foodRecipient).toBe('Valid Org');
+  });
+
+  it('never emits null needScore when source numeric fields contain NaN', () => {
+    const recipients: NonprofitDeliveryData[] = [
+      {
+        recipient: 'Org A',
+        daysSinceLastDelivery: 8,
+        priorityLevel: Number.NaN,
+        totalPoundsThisMonth: 100,
+        totalDeliveriesThisMonth: 2,
+        deliveryFrequency: 'Low',
+        location: 'A',
+      },
+      {
+        recipient: 'Org B',
+        daysSinceLastDelivery: 2,
+        priorityLevel: 2,
+        totalPoundsThisMonth: 120,
+        totalDeliveriesThisMonth: 4,
+        deliveryFrequency: 'Medium',
+        location: 'B',
+      },
+    ];
+
+    const queue = generateDeliveryQueue(recipients);
+
+    expect(queue).toHaveLength(2);
+    for (const row of queue) {
+      expect(typeof row.needScore).toBe('number');
+      expect(Number.isFinite(row.needScore)).toBe(true);
+      expect(Object.keys(row).sort()).toEqual([
+        'daysSinceLastDelivery',
+        'foodRecipient',
+        'location',
+        'needScore',
+      ]);
+    }
+  });
+});

--- a/apps/server/src/__tests__/deliveryQueueService.test.ts
+++ b/apps/server/src/__tests__/deliveryQueueService.test.ts
@@ -182,7 +182,9 @@ describe('generateDeliveryQueue', () => {
     expect(needsDays?.needScore).toBeGreaterThan(0);
     expect(baselineA?.needScore).toBe(0);
   });
+});
 
+describe('generateDeliveryQueue missing-data behavior', () => {
   it('treats missing priority as neutral and still includes recipients', () => {
     const recipients: NonprofitDeliveryData[] = [
       {
@@ -212,7 +214,7 @@ describe('generateDeliveryQueue', () => {
     expect(queue[1]?.needScore).toBe(0);
   });
 
-  it('excludes recipients with missing non-priority required scoring inputs', () => {
+  it('treats missing non-priority scoring fields as neutral and includes recipients', () => {
     const recipients: NonprofitDeliveryData[] = [
       {
         recipient: 'Missing Days',
@@ -221,7 +223,7 @@ describe('generateDeliveryQueue', () => {
         totalPoundsThisMonth: 100,
         totalDeliveriesThisMonth: 3,
         deliveryFrequency: 'Low',
-        location: 'A',
+        location: undefined,
       },
       {
         recipient: 'Valid Org',
@@ -235,9 +237,15 @@ describe('generateDeliveryQueue', () => {
     ];
 
     const queue = generateDeliveryQueue(recipients);
+    const missingDays = queue.find((r) => r.foodRecipient === 'Missing Days');
+    const validOrg = queue.find((r) => r.foodRecipient === 'Valid Org');
 
-    expect(queue).toHaveLength(1);
-    expect(queue[0]?.foodRecipient).toBe('Valid Org');
+    expect(queue).toHaveLength(2);
+    expect(missingDays).toBeDefined();
+    expect(validOrg).toBeDefined();
+    expect(missingDays?.location).toBeNull();
+    expect(typeof missingDays?.needScore).toBe('number');
+    expect(Number.isFinite(missingDays?.needScore ?? Number.NaN)).toBe(true);
   });
 
   it('never emits null needScore when source numeric fields contain NaN', () => {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -7,6 +7,7 @@ import { corsOptions } from './middleware/cors';
 import { errorHandler } from './middleware/errorHandler';
 import { rateLimit } from './middleware/rateLimit';
 import donationRoutes from './routes/donations';
+import deliveriesRoutes from './routes/deliveries';
 import recipientRoutes from './routes/recipients';
 import sheetsRoutes from './routes/sheets';
 
@@ -27,6 +28,7 @@ app.get('/health', (req: Request, res: Response) => {
 });
 
 app.use('/donations', authentication, donationRoutes);
+app.use('/deliveries', authentication, deliveriesRoutes);
 app.use('/sheets', authentication, sheetsRoutes);
 app.use('/recipients', authentication, recipientRoutes);
 app.use('/testing', testing);

--- a/apps/server/src/routes/deliveries.ts
+++ b/apps/server/src/routes/deliveries.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+
+import { generateDeliveryQueue } from '../services/deliveryQueueService';
+import { getParsedNonprofitData } from '../services/googleSheetsService';
+
+const router = Router();
+
+router.get('/queue', async (req, res, next) => {
+  try {
+    const parsedData = await getParsedNonprofitData();
+    const queue = generateDeliveryQueue(parsedData);
+    res.json(queue);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/server/src/services/deliveryQueueService.ts
+++ b/apps/server/src/services/deliveryQueueService.ts
@@ -136,23 +136,7 @@ export const generateDeliveryQueue = (
       .filter((value): value is number => value !== null),
   );
 
-  const hasAllScoringInputs = (
-    recipient: NonprofitDeliveryData,
-  ): recipient is NonprofitDeliveryData & {
-    daysSinceLastDelivery: number;
-    totalPoundsThisMonth: number;
-    totalDeliveriesThisMonth: number;
-  } => {
-    return (
-      Number.isFinite(recipient.daysSinceLastDelivery) &&
-      Number.isFinite(recipient.totalPoundsThisMonth) &&
-      Number.isFinite(recipient.totalDeliveriesThisMonth) &&
-      getFrequencyScore(recipient.deliveryFrequency) !== null
-    );
-  };
-
   return recipients
-    .filter(hasAllScoringInputs)
     .map((recipient) => {
       const weightedSum =
         weightedAbove(recipient.daysSinceLastDelivery, daysStats, 0.35) +

--- a/apps/server/src/services/deliveryQueueService.ts
+++ b/apps/server/src/services/deliveryQueueService.ts
@@ -1,0 +1,194 @@
+import { calcMedian, calcStdDev } from '../utils/stats';
+
+export type DeliveryFrequency = 'None' | 'Low' | 'Medium' | 'High';
+
+export interface NonprofitDeliveryData {
+  recipient: string;
+  daysSinceLastDelivery: number | null;
+  priorityLevel: number | null | undefined;
+  totalPoundsThisMonth: number;
+  totalDeliveriesThisMonth: number;
+  deliveryFrequency: DeliveryFrequency;
+  location: string | null | undefined;
+}
+
+export interface DeliveryQueueRecipient {
+  foodRecipient: string;
+  needScore: number;
+  location: string | null;
+  daysSinceLastDelivery: number | null;
+}
+
+interface MetricStats {
+  median: number;
+  std: number;
+}
+
+const FREQUENCY_SCORES: Record<DeliveryFrequency, number> = {
+  None: 0,
+  Low: 1,
+  Medium: 2,
+  High: 3,
+};
+
+const toFiniteNumberOrNull = (
+  value: number | null | undefined,
+): number | null => {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return value;
+};
+
+const getFrequencyScore = (value: string): number | null => {
+  if (value in FREQUENCY_SCORES) {
+    return FREQUENCY_SCORES[value as DeliveryFrequency];
+  }
+
+  return null;
+};
+
+const getMetricStats = (values: number[]): MetricStats | null => {
+  const finiteValues = values.filter((v) => Number.isFinite(v));
+  if (finiteValues.length === 0) {
+    return null;
+  }
+
+  return {
+    median: calcMedian(finiteValues),
+    std: calcStdDev(finiteValues),
+  };
+};
+
+const getZScore = (value: number, stats: MetricStats | null): number => {
+  if (!stats || stats.std === 0) {
+    return 0;
+  }
+
+  return (value - stats.median) / stats.std;
+};
+
+const weightedAbove = (
+  value: number | null | undefined,
+  stats: MetricStats | null,
+  weight: number,
+): number => {
+  const safeValue = toFiniteNumberOrNull(value);
+  if (safeValue === null) {
+    return 0;
+  }
+
+  return weight * Math.max(getZScore(safeValue, stats), 0);
+};
+
+const weightedBelow = (
+  value: number | null | undefined,
+  stats: MetricStats | null,
+  weight: number,
+): number => {
+  const safeValue = toFiniteNumberOrNull(value);
+  if (safeValue === null) {
+    return 0;
+  }
+
+  return weight * Math.max(-getZScore(safeValue, stats), 0);
+};
+
+const roundNeedScore = (value: number): number => {
+  return Number(value.toFixed(1));
+};
+
+const daysSortValue = (daysSinceLastDelivery: number | null): number => {
+  return daysSinceLastDelivery ?? -1;
+};
+
+export const generateDeliveryQueue = (
+  recipients: readonly NonprofitDeliveryData[],
+): DeliveryQueueRecipient[] => {
+  const daysStats = getMetricStats(
+    recipients
+      .map((r) => r.daysSinceLastDelivery)
+      .filter((value): value is number => Number.isFinite(value)),
+  );
+
+  const priorityStats = getMetricStats(
+    recipients
+      .map((r) => r.priorityLevel)
+      .filter((value): value is number => Number.isFinite(value)),
+  );
+
+  const poundsStats = getMetricStats(
+    recipients
+      .map((r) => r.totalPoundsThisMonth)
+      .filter((value): value is number => Number.isFinite(value)),
+  );
+
+  const deliveriesStats = getMetricStats(
+    recipients
+      .map((r) => r.totalDeliveriesThisMonth)
+      .filter((value): value is number => Number.isFinite(value)),
+  );
+
+  const frequencyStats = getMetricStats(
+    recipients
+      .map((r) => getFrequencyScore(r.deliveryFrequency))
+      .filter((value): value is number => value !== null),
+  );
+
+  const hasAllScoringInputs = (
+    recipient: NonprofitDeliveryData,
+  ): recipient is NonprofitDeliveryData & {
+    daysSinceLastDelivery: number;
+    totalPoundsThisMonth: number;
+    totalDeliveriesThisMonth: number;
+  } => {
+    return (
+      Number.isFinite(recipient.daysSinceLastDelivery) &&
+      Number.isFinite(recipient.totalPoundsThisMonth) &&
+      Number.isFinite(recipient.totalDeliveriesThisMonth) &&
+      getFrequencyScore(recipient.deliveryFrequency) !== null
+    );
+  };
+
+  return recipients
+    .filter(hasAllScoringInputs)
+    .map((recipient) => {
+      const weightedSum =
+        weightedAbove(recipient.daysSinceLastDelivery, daysStats, 0.35) +
+        weightedBelow(recipient.priorityLevel, priorityStats, 0.25) +
+        weightedBelow(recipient.totalPoundsThisMonth, poundsStats, 0.2) +
+        weightedBelow(
+          recipient.totalDeliveriesThisMonth,
+          deliveriesStats,
+          0.15,
+        ) +
+        weightedBelow(
+          getFrequencyScore(recipient.deliveryFrequency),
+          frequencyStats,
+          0.05,
+        );
+
+      return {
+        foodRecipient: recipient.recipient,
+        needScore: roundNeedScore(100 * weightedSum),
+        location: recipient.location ?? null,
+        daysSinceLastDelivery: recipient.daysSinceLastDelivery,
+      };
+    })
+    .sort((a, b) => {
+      if (b.needScore !== a.needScore) {
+        return b.needScore - a.needScore;
+      }
+
+      const dayDiff =
+        daysSortValue(b.daysSinceLastDelivery) -
+        daysSortValue(a.daysSinceLastDelivery);
+      if (dayDiff !== 0) {
+        return dayDiff;
+      }
+
+      return a.foodRecipient.localeCompare(b.foodRecipient);
+    })
+    .slice(0, 5);
+};


### PR DESCRIPTION
feat: added computed weighted NeedScore queue and return top 5 recipients based on total weight, Any field with null or missing should contribute netural 0 weight.
Currently - priority level is neutral when none is listed so it will be a 0 out of 5

